### PR TITLE
java and genericjmx plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ documentation for each plugin for configurable attributes.
 * `entropy`  (see [collectd::plugin::entropy](#class-collectdpluginentropy) below)
 * `exec`  (see [collectd::plugin::exec](#class-collectdpluginexec) below)
 * `filecount` (see [collectd::plugin::filecount](#class-collectdpluginfilecount) below)
+* `genericjmx` (see [collectd::plugin::genericjmx](#class-collectdplugingenericjmx) below)
 * `interface` (see [collectd::plugin::interface](#class-collectdplugininterface) below)
 * `iptables` (see [collectd::plugin::iptables](#class-collectdpluginiptables) below)
 * `irq` (see [collectd::plugin::irq](#class-collectdpluginirq) below)
+* `java` (see [collectd::plugin::java](#class-collectdpluginjava) below)
 * `load` (see [collectd::plugin::load](#class-collectdpluginload) below)
 * `logfile` (see [collectd::plugin::logfile](#class-collectdpluginlogfile) below)
 * `libvirt` (see [collectd::plugin::libvirt](#class-collectdpluginlibvirt) below)
@@ -302,6 +304,41 @@ class { 'collectd::plugin::filecount':
   },
 }
 ```
+
+####Class: `collectd::plugin::genericjmx`
+
+```puppet
+include collectd::plugin::genericjmx
+
+collectd::plugin::genericjmx::mbean {
+  'garbage_collector':
+    object_name     => 'java.lang:type=GarbageCollector,*',
+    instance_prefix => 'gc-',
+    instance_from   => 'name',
+    values          => [
+      {
+        type      => 'invocations',
+        table     => false,
+        attribute => 'CollectionCount',
+      },
+      {
+        type            => 'total_time_in_ms',
+        instance_prefix => 'collection_time',
+        table           => false,
+        attribute       => 'CollectionTime',
+      },
+    ];
+}
+
+collectd::plugin::genericjmx::connection {
+  'java_app':
+    host            => $fqdn,
+    service_url     => 'service:jmx:rmi:///jndi/rmi://localhost:3637/jmxrmi',
+    collect         => [ 'memory-heap', 'memory-nonheap','garbage_collector' ],
+}
+
+```
+
 ####Class: `collectd::plugin::interface`
 
 ```puppet
@@ -329,6 +366,12 @@ class { 'collectd::plugin::iptables':
     'filter' => 'HTTP'
   },
 }
+```
+
+####Class: `collectd::plugin::java`
+
+```puppet
+class { 'collectd::plugin::java': }
 ```
 
 ####Class: `collectd::plugin::load`

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = "${collectd_dir}/collectd.conf"
       $root_group        = 'root'
-      # FIXME: $java_dir
+      $java_dir          = undef
     }
     'Redhat': {
       $package           = 'collectd'
@@ -40,7 +40,7 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = '/etc/collectd.conf'
       $root_group        = 'root'
-      # FIXME: $java_dir
+      $java_dir          = undef
     }
     'FreeBSD': {
       $package           = 'collectd5'
@@ -50,7 +50,7 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = '/usr/local/etc/collectd.conf'
       $root_group        = 'wheel'
-      # FIXME: $java_dir
+      $java_dir          = undef
     }
     'Archlinux': {
       $package           = 'collectd'
@@ -60,7 +60,7 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = '/etc/collectd.conf'
       $root_group        = 'wheel'
-      # FIXME: $java_dir
+      $java_dir          = undef
     }
     'Gentoo': {
       $package           = 'app-admin/collectd'
@@ -70,7 +70,7 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = '/etc/collectd.conf'
       $root_group        = 'collectd'
-      # FIXME: $java_dir
+      $java_dir          = undef
     }
 
     default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = "${collectd_dir}/collectd.conf"
       $root_group        = 'root'
+      $java_dir          = '/usr/share/collectd/java'
     }
     'Solaris': {
       $package           = 'CSWcollectd'
@@ -19,6 +20,7 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = "${collectd_dir}/collectd.conf"
       $root_group        = 'root'
+      # FIXME: $java_dir
     }
     'Redhat': {
       $package           = 'collectd'
@@ -28,6 +30,7 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = '/etc/collectd.conf'
       $root_group        = 'root'
+      $java_dir          = '/usr/share/collectd/java'
     }
     'Suse': {
       $package           = 'collectd'
@@ -37,6 +40,7 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = '/etc/collectd.conf'
       $root_group        = 'root'
+      # FIXME: $java_dir
     }
     'FreeBSD': {
       $package           = 'collectd5'
@@ -46,6 +50,7 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = '/usr/local/etc/collectd.conf'
       $root_group        = 'wheel'
+      # FIXME: $java_dir
     }
     'Archlinux': {
       $package           = 'collectd'
@@ -55,6 +60,7 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = '/etc/collectd.conf'
       $root_group        = 'wheel'
+      # FIXME: $java_dir
     }
     'Gentoo': {
       $package           = 'app-admin/collectd'
@@ -64,6 +70,7 @@ class collectd::params {
       $service_name      = 'collectd'
       $config_file       = '/etc/collectd.conf'
       $root_group        = 'collectd'
+      # FIXME: $java_dir
     }
 
     default: {

--- a/manifests/plugin/genericjmx.pp
+++ b/manifests/plugin/genericjmx.pp
@@ -1,6 +1,5 @@
 # https://collectd.org/wiki/index.php/Plugin:GenericJMX
 class collectd::plugin::genericjmx (
-  $ensure = present,
   $jvmarg = [],
 ) {
   include collectd
@@ -10,7 +9,6 @@ class collectd::plugin::genericjmx (
   $config_file = "${collectd::params::plugin_conf_dir}/15-genericjmx.conf"
 
   concat { $config_file:
-    ensure         => $ensure,
     mode           => '0640',
     owner          => 'root',
     group          => $collectd::params::root_group,

--- a/manifests/plugin/genericjmx.pp
+++ b/manifests/plugin/genericjmx.pp
@@ -6,7 +6,7 @@ class collectd::plugin::genericjmx (
   include collectd
   include collectd::params
   include collectd::plugin::java
-
+  $class_path = "${collectd::params::java_dir}/collectd-api.jar:${collectd::params::java_dir}/generic-jmx.jar"
   $config_file = "${collectd::params::plugin_conf_dir}/15-genericjmx.conf"
 
   concat { $config_file:

--- a/manifests/plugin/genericjmx.pp
+++ b/manifests/plugin/genericjmx.pp
@@ -1,0 +1,31 @@
+# https://collectd.org/wiki/index.php/Plugin:GenericJMX
+class collectd::plugin::genericjmx (
+  $ensure = present,
+  $jvmarg = [],
+) {
+  include collectd
+  include collectd::params
+  include collectd::plugin::java
+
+  $config_file = "${collectd::params::plugin_conf_dir}/15-genericjmx.conf"
+
+  concat { $config_file:
+    ensure         => $ensure,
+    mode           => '0640',
+    owner          => 'root',
+    group          => $collectd::params::root_group,
+    notify         => Service['collectd'],
+    ensure_newline => true,
+  }
+  concat::fragment {
+    'collectd_plugin_genericjmx_conf_header':
+      order   => '00',
+      content => template('collectd/plugin/genericjmx.conf.header.erb'),
+      target  => $config_file;
+    'collectd_plugin_genericjmx_conf_footer':
+      order   => '99',
+      content => "  </Plugin>\n</Plugin>\n",
+      target  => $config_file;
+  }
+
+}

--- a/manifests/plugin/genericjmx/connection.pp
+++ b/manifests/plugin/genericjmx/connection.pp
@@ -1,0 +1,16 @@
+# https://collectd.org/wiki/index.php/Plugin:GenericJMX
+define collectd::plugin::genericjmx::connection (
+  $host = $name,
+  $service_url,
+  $user = undef,
+  $password = undef,
+  $instance_prefix = undef,
+  $collect,
+) {
+  include collectd::plugin::genericjmx
+  concat::fragment { "collectd_plugin_genericjmx_conf_${name}":
+    order   => 20,
+    content => template('collectd/plugin/genericjmx/connection.conf.erb'),
+    target  => $collectd::plugin::genericjmx::config_file;
+  }
+}

--- a/manifests/plugin/genericjmx/mbean.pp
+++ b/manifests/plugin/genericjmx/mbean.pp
@@ -1,0 +1,17 @@
+# https://collectd.org/wiki/index.php/Plugin:GenericJMX
+define collectd::plugin::genericjmx::mbean (
+  $object_name,
+  $instance_prefix = undef,
+  $instance_from = undef,
+  $values,
+) {
+  include collectd::plugin::genericjmx
+  validate_array($values)
+
+  concat::fragment {
+    "collectd_plugin_genericjmx_conf_${name}":
+      order   => '10',
+      content => template('collectd/plugin/genericjmx/mbean.conf.erb'),
+      target  => $collectd::plugin::genericjmx::config_file;
+  }
+}

--- a/manifests/plugin/java.pp
+++ b/manifests/plugin/java.pp
@@ -1,0 +1,12 @@
+# https://collectd.org/wiki/index.php/Plugin:Java
+class collectd::plugin::java (
+  $ensure   = present,
+  $jvmarg   = [],
+  $interval = undef,
+) {
+  collectd::plugin { 'java':
+    ensure   => $ensure,
+    content  => template('collectd/plugin/java.conf.erb'),
+    interval => $interval,
+  }
+}

--- a/spec/classes/collectd_plugin_genericjmx_spec.rb
+++ b/spec/classes/collectd_plugin_genericjmx_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe 'collectd::plugin::genericjmx', :type => :class do
   let (:facts) {{
-    :osfamily       => 'RedHat',
+    :osfamily       => 'Debian',
     :concat_basedir => tmpfilename('collectd-genericjmx'),
   }}
 
-  let (:config_filename) { '/etc/collectd.d/15-genericjmx.conf' }
+  let (:config_filename) { '/etc/collectd/conf.d/15-genericjmx.conf' }
 
   context ':ensure => present, defaults' do
     it 'will include the java plugin' do
@@ -64,15 +64,15 @@ describe 'collectd::plugin::genericjmx', :type => :class do
     it 'should have one jvmarg parameter' do
       should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').with_content(/JVMArg "bat"/)
     end
-    it 'should have ONLY one jvmarg parameter' do
-      should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').without_content(/(.*JVMArg.*){2,}/m)
+    it 'should have ONLY one jvmarg parameter other than classpath' do
+      should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').without_content(/(.*JVMArg.*){3,}/m)
     end
   end
 
   context 'jvmarg parameter empty' do
     let (:params) {{ :jvmarg => [] }}
-    it 'should not have any jvmarg parameters' do
-      should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').without_content(/JVMArg/)
+    it 'should wnot have any jvmarg parameters other than classpath' do
+      should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').without_content(/(.*JVMArg.*){2,}/m)
     end
   end
 end

--- a/spec/classes/collectd_plugin_genericjmx_spec.rb
+++ b/spec/classes/collectd_plugin_genericjmx_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 describe 'collectd::plugin::genericjmx', :type => :class do
   let (:facts) {{
     :osfamily       => 'Debian',
+    :id             => 'root',
     :concat_basedir => tmpfilename('collectd-genericjmx'),
+    :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
   }}
 
   let (:config_filename) { '/etc/collectd/conf.d/15-genericjmx.conf' }

--- a/spec/classes/collectd_plugin_genericjmx_spec.rb
+++ b/spec/classes/collectd_plugin_genericjmx_spec.rb
@@ -10,7 +10,7 @@ describe 'collectd::plugin::genericjmx', :type => :class do
 
   let (:config_filename) { '/etc/collectd/conf.d/15-genericjmx.conf' }
 
-  context ':ensure => present, defaults' do
+  context 'defaults' do
     it 'will include the java plugin' do
       should contain_class('collectd::plugin::java')
     end
@@ -45,15 +45,6 @@ describe 'collectd::plugin::genericjmx', :type => :class do
 
   end
 
-  context ':ensure => absent' do
-    let (:params) {{ :ensure => 'absent' }}
-    it 'should not load the plugin' do
-      should contain_concat(config_filename).with({
-        :ensure => 'absent',
-      })
-    end
-  end
-
   context 'jvmarg parameter array' do
     let (:params) {{ :jvmarg => %w{ foo bar baz } }}
     it 'should have multiple jvmarg parameters' do
@@ -73,7 +64,7 @@ describe 'collectd::plugin::genericjmx', :type => :class do
 
   context 'jvmarg parameter empty' do
     let (:params) {{ :jvmarg => [] }}
-    it 'should wnot have any jvmarg parameters other than classpath' do
+    it 'should not have any jvmarg parameters other than classpath' do
       should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').without_content(/(.*JVMArg.*){2,}/m)
     end
   end

--- a/spec/classes/collectd_plugin_genericjmx_spec.rb
+++ b/spec/classes/collectd_plugin_genericjmx_spec.rb
@@ -29,7 +29,7 @@ describe 'collectd::plugin::genericjmx', :type => :class do
       should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').with({
         :order   => '00',
         :target  => config_filename,
-        :content => /<Plugin "java">\s+LoadPlugin "org\.collectd\.java\.GenericJMX"\s+<Plugin "GenericJMX">/s
+        :content => /<Plugin "java">.+LoadPlugin "org\.collectd\.java\.GenericJMX".+<Plugin "GenericJMX">/m
       })
     end
 
@@ -37,7 +37,7 @@ describe 'collectd::plugin::genericjmx', :type => :class do
       should contain_concat__fragment('collectd_plugin_genericjmx_conf_footer').with({
         :order   => '99',
         :target  => config_filename,
-        :content => %r{</Plugin>\s+</Plugin>}s,
+        :content => %r{</Plugin>.+</Plugin>}m,
       })
     end
 
@@ -55,7 +55,7 @@ describe 'collectd::plugin::genericjmx', :type => :class do
   context 'jvmarg parameter array' do
     let (:params) {{ :jvmarg => %w{ foo bar baz } }}
     it 'should have multiple jvmarg parameters' do
-      should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').with_content(/JVMArg "foo"\s*JVMArg "bar"\s*JVMArg "baz"/s)
+      should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').with_content(/JVMArg "foo".*JVMArg "bar".*JVMArg "baz"/m)
     end
   end
 
@@ -65,7 +65,7 @@ describe 'collectd::plugin::genericjmx', :type => :class do
       should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').with_content(/JVMArg "bat"/)
     end
     it 'should have ONLY one jvmarg parameter' do
-      should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').without_content(/(.*JVMArg.*){2,}/s)
+      should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').without_content(/(.*JVMArg.*){2,}/m)
     end
   end
 

--- a/spec/classes/collectd_plugin_genericjmx_spec.rb
+++ b/spec/classes/collectd_plugin_genericjmx_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::genericjmx', :type => :class do
+  let (:facts) {{
+    :osfamily       => 'RedHat',
+    :concat_basedir => tmpfilename('collectd-genericjmx'),
+  }}
+
+  let (:config_filename) { '/etc/collectd.d/15-genericjmx.conf' }
+
+  context ':ensure => present, defaults' do
+    it 'will include the java plugin' do
+      should contain_class('collectd::plugin::java')
+    end
+
+    it 'will load the genericjmx plugin' do
+      should contain_concat(config_filename).with({
+        :ensure         => 'present',
+        :mode           => '0640',
+        :owner          => 'root',
+        :group          => 'root',
+        :ensure_newline => true
+      })
+    end
+
+    it { should contain_concat(config_filename).that_notifies('Service[collectd]') }
+
+    it do
+      should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').with({
+        :order   => '00',
+        :target  => config_filename,
+        :content => /<Plugin "java">\s+LoadPlugin "org\.collectd\.java\.GenericJMX"\s+<Plugin "GenericJMX">/s
+      })
+    end
+
+    it do
+      should contain_concat__fragment('collectd_plugin_genericjmx_conf_footer').with({
+        :order   => '99',
+        :target  => config_filename,
+        :content => %r{</Plugin>\s+</Plugin>}s,
+      })
+    end
+
+  end
+
+  context ':ensure => absent' do
+    let (:params) {{ :ensure => 'absent' }}
+    it 'should not load the plugin' do
+      should contain_concat(config_filename).with({
+        :ensure => 'absent',
+      })
+    end
+  end
+
+  context 'jvmarg parameter array' do
+    let (:params) {{ :jvmarg => %w{ foo bar baz } }}
+    it 'should have multiple jvmarg parameters' do
+      should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').with_content(/JVMArg "foo"\s*JVMArg "bar"\s*JVMArg "baz"/s)
+    end
+  end
+
+  context 'jvmarg parameter string' do
+    let (:params) {{ :jvmarg => "bat" }}
+    it 'should have one jvmarg parameter' do
+      should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').with_content(/JVMArg "bat"/)
+    end
+    it 'should have ONLY one jvmarg parameter' do
+      should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').without_content(/(.*JVMArg.*){2,}/s)
+    end
+  end
+
+  context 'jvmarg parameter empty' do
+    let (:params) {{ :jvmarg => [] }}
+    it 'should not have any jvmarg parameters' do
+      should contain_concat__fragment('collectd_plugin_genericjmx_conf_header').without_content(/JVMArg/)
+    end
+  end
+end
+

--- a/spec/classes/collectd_plugin_java_spec.rb
+++ b/spec/classes/collectd_plugin_java_spec.rb
@@ -12,7 +12,6 @@ describe 'collectd::plugin::java', :type => :class do
         :path => '/etc/collectd.d/10-java.conf',
       })
 
-      should contain_file('java.load').with_content(/<Plugin java>/)
       should contain_file('java.load').without_content(/JVMArg/)
     end
   end
@@ -51,6 +50,16 @@ describe 'collectd::plugin::java', :type => :class do
 
     it 'will only have one JVMArg bit' do
       should contain_file('java.load').without_content(/(.*JVMArg.*){2,}/)
+    end
+  end
+
+  context 'jvmarg parameter empty' do
+    let (:params) {{
+      :jvmarg => [],
+    }}
+
+    it 'will not have a <Plugin java> stanza' do
+      should contain_file('java.load').without_content(/<Plugin java>/)
     end
   end
 end

--- a/spec/classes/collectd_plugin_java_spec.rb
+++ b/spec/classes/collectd_plugin_java_spec.rb
@@ -7,12 +7,11 @@ describe 'collectd::plugin::java', :type => :class do
 
   context ':ensure => present, defaults' do
     it 'Will load the plugin' do
-      should contain_file('java.load').with({
+      should contain_collectd__plugin('java').with({
         :ensure => 'present',
-        :path => '/etc/collectd.d/10-java.conf',
       })
 
-      should contain_file('java.load').without_content(/JVMArg/)
+      should contain_collectd__plugin('java').without_content(/JVMArg/)
     end
   end
 
@@ -22,9 +21,8 @@ describe 'collectd::plugin::java', :type => :class do
     }}
 
     it 'will not load the plugin' do
-      should contain_file('java.load').with({
-        :ensure => 'absent',
-        :path => '/etc/collectd.d/10-java.conf',
+      should contain_collectd__plugin('java').with({
+        :ensure => 'absent'
       })
     end
   end
@@ -35,7 +33,7 @@ describe 'collectd::plugin::java', :type => :class do
     }}
 
     it 'will have multiple JVMArg bits' do
-      should contain_file('java.load').with_content(/JVMArg "foo"[\s\n]+JVMArg "bar"[\s\n]+JVMArg "baz"/)
+      should contain_collectd__plugin('java').with_content(/JVMArg "foo"[\s\n]+JVMArg "bar"[\s\n]+JVMArg "baz"/)
     end
   end
 
@@ -45,11 +43,11 @@ describe 'collectd::plugin::java', :type => :class do
     }}
 
     it 'will have a JVMArg bit' do
-      should contain_file('java.load').with_content(/JVMArg "bat"/)
+      should contain_collectd__plugin('java').with_content(/JVMArg "bat"/)
     end
 
     it 'will only have one JVMArg bit' do
-      should contain_file('java.load').without_content(/(.*JVMArg.*){2,}/)
+      should contain_collectd__plugin('java').without_content(/(.*JVMArg.*){2,}/)
     end
   end
 
@@ -59,8 +57,7 @@ describe 'collectd::plugin::java', :type => :class do
     }}
 
     it 'will not have a <Plugin java> stanza' do
-      should contain_file('java.load').without_content(/<Plugin java>/)
+      should contain_collectd__plugin('java').without_content(/<Plugin java>/)
     end
   end
 end
-

--- a/spec/classes/collectd_plugin_java_spec.rb
+++ b/spec/classes/collectd_plugin_java_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::java', :type => :class do
+  let :facts do
+    {:osfamily => 'RedHat'}
+  end
+
+  context ':ensure => present, defaults' do
+    it 'Will load the plugin' do
+      should contain_file('java.load').with({
+        :ensure => 'present',
+        :path => '/etc/collectd.d/10-java.conf',
+      })
+
+      should contain_file('java.load').with_content(/<Plugin java>/)
+      should contain_file('java.load').without_content(/JVMArg/)
+    end
+  end
+
+  context ':ensure => absent' do
+    let (:params) {{
+      :ensure => 'absent',
+    }}
+
+    it 'will not load the plugin' do
+      should contain_file('java.load').with({
+        :ensure => 'absent',
+        :path => '/etc/collectd.d/10-java.conf',
+      })
+    end
+  end
+
+  context 'jvmarg parameter array' do
+    let (:params) {{
+      :jvmarg => %w{ foo bar baz }
+    }}
+
+    it 'will have multiple JVMArg bits' do
+      should contain_file('java.load').with_content(/JVMArg "foo"[\s\n]+JVMArg "bar"[\s\n]+JVMArg "baz"/)
+    end
+  end
+
+  context 'jvmarg parameter string' do
+    let (:params) {{
+      :jvmarg => 'bat'
+    }}
+
+    it 'will have a JVMArg bit' do
+      should contain_file('java.load').with_content(/JVMArg "bat"/)
+    end
+
+    it 'will only have one JVMArg bit' do
+      should contain_file('java.load').without_content(/(.*JVMArg.*){2,}/)
+    end
+  end
+end
+

--- a/spec/classes/collectd_plugin_java_spec.rb
+++ b/spec/classes/collectd_plugin_java_spec.rb
@@ -10,8 +10,6 @@ describe 'collectd::plugin::java', :type => :class do
       should contain_collectd__plugin('java').with({
         :ensure => 'present',
       })
-
-      should contain_collectd__plugin('java').without_content(/JVMArg/)
     end
   end
 
@@ -32,7 +30,7 @@ describe 'collectd::plugin::java', :type => :class do
       :jvmarg => %w{ foo bar baz }
     }}
 
-    it 'will have multiple JVMArg bits' do
+    it 'will have multiple jvmarg parameters' do
       should contain_collectd__plugin('java').with_content(/JVMArg "foo"[\s\n]+JVMArg "bar"[\s\n]+JVMArg "baz"/)
     end
   end
@@ -42,11 +40,11 @@ describe 'collectd::plugin::java', :type => :class do
       :jvmarg => 'bat'
     }}
 
-    it 'will have a JVMArg bit' do
+    it 'will have a JVMArg parameter' do
       should contain_collectd__plugin('java').with_content(/JVMArg "bat"/)
     end
 
-    it 'will only have one JVMArg bit' do
+    it 'will only have one JVMArg parameter' do
       should contain_collectd__plugin('java').without_content(/(.*JVMArg.*){2,}/)
     end
   end
@@ -58,6 +56,9 @@ describe 'collectd::plugin::java', :type => :class do
 
     it 'will not have a <Plugin java> stanza' do
       should contain_collectd__plugin('java').without_content(/<Plugin java>/)
+    end
+    it 'will not have any jvmarg parameters' do
+      should contain_collectd__plugin('java').without_content(/JVMArg/)
     end
   end
 end

--- a/spec/classes/collectd_plugin_java_spec.rb
+++ b/spec/classes/collectd_plugin_java_spec.rb
@@ -31,7 +31,7 @@ describe 'collectd::plugin::java', :type => :class do
     }}
 
     it 'will have multiple jvmarg parameters' do
-      should contain_collectd__plugin('java').with_content(/JVMArg "foo"[\s\n]+JVMArg "bar"[\s\n]+JVMArg "baz"/)
+      should contain_collectd__plugin('java').with_content(/JVMArg "foo".+JVMArg "bar".+JVMArg "baz"/m)
     end
   end
 
@@ -45,7 +45,7 @@ describe 'collectd::plugin::java', :type => :class do
     end
 
     it 'will only have one JVMArg parameter' do
-      should contain_collectd__plugin('java').without_content(/(.*JVMArg.*){2,}/)
+      should contain_collectd__plugin('java').without_content(/(.*JVMArg.*){2,}/m)
     end
   end
 

--- a/spec/defines/collectd_plugin_genericjmx_connection_spec.rb
+++ b/spec/defines/collectd_plugin_genericjmx_connection_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+describe 'collectd::plugin::genericjmx::connection', :type => :define do
+
+  let (:facts) {{
+    :osfamily  => 'Debian',
+    :concat_basedir => tmpfilename('collectd-genericjmx-connection'),
+  }}
+
+  let (:config_filename) { '/etc/collectd/conf.d/15-genericjmx.conf' }
+
+  let (:default_params) {{
+    :service_url => 'foo:bar:baz',
+  }}
+
+  let (:title) { 'foo.example.com' }
+  let (:concat_fragment_name) { 'collectd_plugin_genericjmx_conf_foo.example.com' }
+
+  context 'required params' do
+    let (:params) {
+      default_params.merge({
+        :collect => [],
+      })
+    }
+
+    it 'provides a Connection concat fragment' do
+      should contain_concat__fragment(concat_fragment_name).with({
+        :target => config_filename,
+        :order => '20',
+      })
+    end
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(%r{<Connection>.*</Connection>}m) }
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/Host "foo\.example\.com"/) }
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/ServiceURL "foo:bar:baz"/) }
+    it { should contain_concat__fragment(concat_fragment_name).without_content(/User/) }
+    it { should contain_concat__fragment(concat_fragment_name).without_content(/Password/) }
+    it { should contain_concat__fragment(concat_fragment_name).without_content(/InstancePrefix/) }
+  end
+
+  context 'hostname override' do
+    let (:params) {
+      default_params.merge({
+        :host => 'bar.example.com',
+        :collect => [],
+      })
+    }
+
+    it 'provides a Connection concat fragment' do
+      should contain_concat__fragment(concat_fragment_name).with({
+        :target => config_filename,
+        :order => '20',
+      })
+    end
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/Host "bar\.example\.com"/) }
+  end
+
+  context 'collect array' do
+    let (:params) {
+      default_params.merge({
+        :collect => %w{ foo bar baz }
+      })
+    }
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/Collect "foo".*Collect "bar".*Collect "baz"/m) }
+  end
+
+  context 'collect string' do
+    let (:params) {
+      default_params.merge({
+        :collect => 'bat'
+      })
+    }
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/Collect "bat"/) }
+    it { should contain_concat__fragment(concat_fragment_name).without_content(/(.*Collect.*){2,}/m) }
+  end
+
+  context 'username and password' do
+    let (:params) {
+      default_params.merge({
+        :user     => 'alice',
+        :password => 'aoeuhtns',
+        :collect  => [],
+      })
+    }
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/User "alice"/) }
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/Password "aoeuhtns"/) }
+  end
+
+  context 'instance_prefix 'do
+    let (:params) {
+      default_params.merge({
+        :instance_prefix => 'bat',
+        :collect  => [],
+      })
+    }
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/InstancePrefix "bat"/) }
+  end
+
+end

--- a/spec/defines/collectd_plugin_genericjmx_connection_spec.rb
+++ b/spec/defines/collectd_plugin_genericjmx_connection_spec.rb
@@ -3,7 +3,9 @@ describe 'collectd::plugin::genericjmx::connection', :type => :define do
 
   let (:facts) {{
     :osfamily  => 'Debian',
+    :id => 'root',
     :concat_basedir => tmpfilename('collectd-genericjmx-connection'),
+    :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
   }}
 
   let (:config_filename) { '/etc/collectd/conf.d/15-genericjmx.conf' }

--- a/spec/defines/collectd_plugin_genericjmx_mbean_spec.rb
+++ b/spec/defines/collectd_plugin_genericjmx_mbean_spec.rb
@@ -1,0 +1,175 @@
+require 'spec_helper'
+
+describe 'collectd::plugin::genericjmx::mbean', :type => :define do
+
+  let (:facts) {{
+    :osfamily  => 'Debian',
+    :concat_basedir => tmpfilename('collectd-genericjmx-mbean'),
+  }}
+
+  let (:config_filename) { '/etc/collectd/conf.d/15-genericjmx.conf' }
+
+  let (:default_params) {{
+    :object_name => 'bar',
+    :values      => [],
+  }}
+
+  let (:title) { 'foo' }
+  let (:concat_fragment_name) { 'collectd_plugin_genericjmx_conf_foo' }
+
+  # empty values array is technically not valid, but we'll test those cases later
+  context 'defaults' do
+    let (:params) { default_params }
+    it 'provides an MBean stanza concat fragment' do
+      should contain_concat__fragment(concat_fragment_name).with({
+        :target => config_filename,
+        :order  => '10',
+      })
+    end
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(%r{<MBean "foo">\s+ObjectName "bar".+</MBean>}m) }
+    it { should contain_concat__fragment(concat_fragment_name).without_content(/InstancePrefix/) }
+    it { should contain_concat__fragment(concat_fragment_name).without_content(/InstanceFrom/) }
+  end
+
+  context 'instance_prefix set' do
+    let (:params) {
+      default_params.merge({
+        :instance_prefix => 'baz'
+      })
+    }
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/InstancePrefix "baz"/) }
+  end
+
+  context 'instance_from array' do
+    let (:params) {
+      default_params.merge({
+        :instance_from => %w{ foo bar baz }
+      })
+    }
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/InstanceFrom "foo"\s+InstanceFrom "bar"\s+InstanceFrom "baz"/) }
+  end
+
+  context 'instance_from string' do
+    let (:params) {
+      default_params.merge({
+        :instance_from => 'bat'
+      })
+    }
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/InstanceFrom "bat"/) }
+    it { should contain_concat__fragment(concat_fragment_name).without_content(/(.*InstanceFrom.*){2,}/) }
+  end
+
+  let (:default_values_args) {{
+    'type'       => 'foo',
+    'attribute'  => 'bar'
+  }}
+
+
+  # testing the Value template section is going to be messy
+  context 'value section defaults' do
+    let (:params) {
+      default_params.merge({
+        :values => [default_values_args]
+      })
+    }
+
+    it 'should have a value stanza' do
+      should contain_concat__fragment(concat_fragment_name).with_content(%r{<Value>.*</Value>}m)
+    end
+
+    it 'should have only one value stanza' do
+      should contain_concat__fragment(concat_fragment_name).without_content(%r{(.*<Value>.*){2,}})
+    end
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/Type "foo"/) }
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/Table false/) }
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/Attribute "bar"/) }
+    it { should contain_concat__fragment(concat_fragment_name).without_content(/InstancePrefix/) }
+    it { should contain_concat__fragment(concat_fragment_name).without_content(/InstanceFrom/) }
+  end
+
+  context 'value section instance_prefix set' do
+    let (:params) {
+      default_params.merge({
+        :values => [default_values_args.merge({
+          'instance_prefix' => 'baz',
+        })]
+      })
+    }
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/InstancePrefix "baz"/) }
+    it { should contain_concat__fragment(concat_fragment_name).without_content(/InstanceFrom/) }
+  end
+
+  context 'value section instance_from array' do
+    let (:params) {
+      default_params.merge({
+        :values => [default_values_args.merge({
+          'instance_from' => %w{ alice bob carol }
+        })]
+      })
+    }
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/InstanceFrom "alice"/) }
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/InstanceFrom "bob"/) }
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/InstanceFrom "carol"/) }
+    it { should contain_concat__fragment(concat_fragment_name).without_content(/InstancePrefix/) }
+  end
+
+  context 'value section instance_from string' do
+    let (:params) {
+      default_params.merge({
+        :values => [default_values_args.merge({
+          'instance_from' => 'dave',
+        })]
+      })
+    }
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(/InstanceFrom "dave"/) }
+    it { should contain_concat__fragment(concat_fragment_name).without_content(/(.*InstancePrefix.*){2,}/) }
+    it { should contain_concat__fragment(concat_fragment_name).without_content(/InstancePrefix/) }
+  end
+
+  context 'value section table true-like' do
+    ['true', true].each do |truthy|
+      let (:params) {
+        default_params.merge({
+          :values => [default_values_args.merge({
+            'table' => truthy
+          })]
+        })
+      }
+
+      it { should contain_concat__fragment(concat_fragment_name).with_content(/Table true/) }
+    end
+  end
+
+  context 'value section table false-like' do
+    ['false', false].each do |truthy|
+      let (:params) {
+        default_params.merge({
+          :values => [default_values_args.merge({
+            'table' => truthy
+          })]
+        })
+      }
+
+      it { should contain_concat__fragment(concat_fragment_name).with_content(/Table false/) }
+    end
+  end
+
+  context 'multiple values' do
+    let (:params) {
+      default_params.merge({
+        :values => [default_values_args,default_values_args]
+      })
+    }
+
+    it { should contain_concat__fragment(concat_fragment_name).with_content(%r{(.*<Value>.*</Value>.*){2}}m) }
+  end
+
+end

--- a/spec/defines/collectd_plugin_genericjmx_mbean_spec.rb
+++ b/spec/defines/collectd_plugin_genericjmx_mbean_spec.rb
@@ -4,7 +4,9 @@ describe 'collectd::plugin::genericjmx::mbean', :type => :define do
 
   let (:facts) {{
     :osfamily  => 'Debian',
+    :id => 'root',
     :concat_basedir => tmpfilename('collectd-genericjmx-mbean'),
+    :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
   }}
 
   let (:config_filename) { '/etc/collectd/conf.d/15-genericjmx.conf' }

--- a/templates/plugin/genericjmx.conf.header.erb
+++ b/templates/plugin/genericjmx.conf.header.erb
@@ -1,0 +1,7 @@
+<Plugin "java">
+<% Array(@jvmarg).each do |jvmarg| -%>
+  JVMArg "<%= jvmarg %>"
+<% end -%>
+
+  LoadPlugin "org.collectd.java.GenericJMX"
+  <Plugin "GenericJMX">

--- a/templates/plugin/genericjmx.conf.header.erb
+++ b/templates/plugin/genericjmx.conf.header.erb
@@ -1,4 +1,5 @@
 <Plugin "java">
+  JVMArg "-Djava.class.path=<%= @class_path %>"
 <% Array(@jvmarg).each do |jvmarg| -%>
   JVMArg "<%= jvmarg %>"
 <% end -%>

--- a/templates/plugin/genericjmx/connection.conf.erb
+++ b/templates/plugin/genericjmx/connection.conf.erb
@@ -1,0 +1,16 @@
+<Connection>
+  Host "<%= @host %>"
+  ServiceURL "<%= @service_url %>"
+  <% Array(@collect).each do |collect| -%>
+  Collect "<%= collect %>"
+  <% end -%>
+  <% if @user -%>
+  User "<%= @user %>"
+  <% end -%>
+  <% if @password -%>
+  Password "<%= @password %>"
+  <% end -%>
+  <% if @instance_prefix -%>
+  InstancePrefix "<%= @instance_prefix %>"
+  <% end -%>
+</Connection>

--- a/templates/plugin/genericjmx/mbean.conf.erb
+++ b/templates/plugin/genericjmx/mbean.conf.erb
@@ -1,25 +1,27 @@
 <MBean "<%= @name %>">
-ObjectName "<%= @object_name %>"
-<% if @instance_prefix -%>
+  ObjectName "<%= @object_name %>"
+  <% if @instance_prefix -%>
   InstancePrefix "<%= @instance_prefix %>"
-<% end -%>
-<% if @instance_from -%>
-  <% Array(@instance_from).each do |instance_from_item| -%>
-    InstanceFrom "<%= instance_from_item %>"
   <% end -%>
-<% end -%>
-
-<% @values.each do |value| -%>
-  <Value>
-    Type "<%= value['type'] %>"
-  <% if value['instance_prefix'] -%>
-    InstancePrefix "<%= value['instance_prefix'] %>"
-  <% end -%>
-  <% if value['instance_from'] -%>
-    <% Array(value['instance_from']).each do |instance_from_item| -%>
-      InstanceFrom "<%= instance_from_item %>"
+  <% if @instance_from -%>
+    <% Array(@instance_from).each do |instance_from_item| -%>
+  InstanceFrom "<%= instance_from_item %>"
     <% end -%>
   <% end -%>
+
+  <% @values.each do |value| -%>
+  <Value>
+    Type "<%= value['type'] %>"
+    <% if value['instance_prefix'] -%>
+    InstancePrefix "<%= value['instance_prefix'] %>"
+    <% end -%>
+    <% if value['instance_from'] -%>
+      <% Array(value['instance_from']).each do |instance_from_item| -%>
+    InstanceFrom "<%= instance_from_item %>"
+      <% end -%>
+    <% end -%>
+    Table <%= scope.function_str2bool([value['table'] || false ]) ? 'true' : 'false' %>
+    Attribute "<%= value['attribute'] %>"
   </Value>
-<% end -%>
+  <% end -%>
 </MBean>

--- a/templates/plugin/genericjmx/mbean.conf.erb
+++ b/templates/plugin/genericjmx/mbean.conf.erb
@@ -1,0 +1,25 @@
+<MBean "<%= @name %>">
+ObjectName "<%= @object_name %>"
+<% if @instance_prefix -%>
+  InstancePrefix "<%= @instance_prefix %>"
+<% end -%>
+<% if @instance_from -%>
+  <% Array(@instance_from).each do |instance_from_item| -%>
+    InstanceFrom "<%= instance_from_item %>"
+  <% end -%>
+<% end -%>
+
+<% @values.each do |value| -%>
+  <Value>
+    Type "<%= value['type'] %>"
+  <% if value['instance_prefix'] -%>
+    InstancePrefix "<%= value['instance_prefix'] %>"
+  <% end -%>
+  <% if value['instance_from'] -%>
+    <% Array(value['instance_from']).each do |instance_from_item| -%>
+      InstanceFrom "<%= instance_from_item %>"
+    <% end -%>
+  <% end -%>
+  </Value>
+<% end -%>
+</MBean>

--- a/templates/plugin/java.conf.erb
+++ b/templates/plugin/java.conf.erb
@@ -1,7 +1,7 @@
+<% if !Array(@jvmarg).empty? -%>
 <Plugin java>
-  <% if @jvmarg -%>
-    <% Array(@jvmarg).each do |arg| -%>
+  <% Array(@jvmarg).each do |arg| -%>
   JVMArg "<%= arg %>"
-    <% end -%>
   <% end -%>
 </Plugin>
+<% end -%>

--- a/templates/plugin/java.conf.erb
+++ b/templates/plugin/java.conf.erb
@@ -1,0 +1,7 @@
+<Plugin java>
+  <% if @jvmarg -%>
+    <% Array(@jvmarg).each do |arg| -%>
+  JVMArg "<%= arg %>"
+    <% end -%>
+  <% end -%>
+</Plugin>


### PR DESCRIPTION
There's a new global param, which needs to be updated for the other platforms. I only have centos, fedora, debian, ubuntu, and freebsd available to me (main platform is ubuntu, others would be coming from DO boxes) and as far as I can tell genericjmx isn't available for redhat, and java isn't available at all for freebsd, so I'm not overly certain how that should be handled, if there should be a check in the class to see if it's a supported platform or...

Also, I'd love it if someone who is using the collectd java plugin and knows how it behaves when it comes to multiple `<Plugin "java">LoadPlugin "foo" ...` blocks, like if the JVMArg parameter is global across all java plugins, or just that block, or what. The only one I have a need for at the moment is genericjmx, so I tried to make everything generic to support that but there may be some undocumented behavior it does that I'm not aware of since I'm only using one java plugin.

Also, on ubuntu (12.04 anyways) this needs openjdk-6-headless to be installed because it needs that specific jvm's libjvm.so (because they don't have an alternative for libjvm.so, so the package is built against a specific jvm... silly :() so this isn't perfectly drop-in, but I tried :)

I'm all for making changes to this to get this to a mergable state. I am currently using it myself on my ubuntu 12.04 boxes, so it does in fact work, but there's probably a fair amount more work required to get it mergable :)