### PR TITLE
plugin/ntpd: IncludeUnitID option only available in collectd > 5.2

### DIFF
--- a/templates/plugin/ntpd.conf.erb
+++ b/templates/plugin/ntpd.conf.erb
@@ -2,5 +2,7 @@
   Host "<%= @host %>"
   Port "<%= @port %>"
   ReverseLookups <%= @reverselookups %>
+<% if @collectd_version and scope.function_versioncmp([@collectd_version, '5.2']) > 0 -%>
   IncludeUnitID <%= @includeunitid %>
+<% end -%>
 </Plugin>


### PR DESCRIPTION
Fixes `Plugin 'ntpd' did not register for value 'IncludeUnitID'.` warnings on Debian.