### PR TITLE
fixed typos

### DIFF
--- a/manifests/plugin/perl.pp
+++ b/manifests/plugin/perl.pp
@@ -25,7 +25,7 @@ class collectd::plugin::perl (
   file { "${conf_dir}/perl":
     ensure => directory,
     mode   => '0755',
-    owner  => $collectd::params::root_user,
+    owner  => 'root',
     group  => $collectd::params::root_group,
   }
 }

--- a/manifests/plugin/perl/plugin.pp
+++ b/manifests/plugin/perl/plugin.pp
@@ -36,7 +36,7 @@ define collectd::plugin::perl::plugin (
   $filename = "${conf_dir}/perl/plugin-${order}_${name}.conf"
 
   file { $filename:
-    owner   => $collectd::params::root_user,
+    owner   => 'root',
     group   => $collectd::params::root_group,
     mode    => '0644',
     content => template('collectd/plugin/perl/plugin.erb'),

--- a/tests/plugin.pp
+++ b/tests/plugin.pp
@@ -16,4 +16,4 @@ collectd::plugin { 'memory': }
 collectd::plugin { 'processes': }
 collectd::plugin { 'swap': }
 collectd::plugin { 'users': }
-collects::plugin { 'cpufreq': }
+collectd::plugin { 'cpufreq': }


### PR DESCRIPTION
$collectd::params::root_user variable doesn't exist
Most likely won't be anything other than 'root'