### PR TITLE
Package collectd-python is no longer available in EPEL

### DIFF
--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -11,12 +11,6 @@ define collectd::plugin::python (
 
   validate_hash($config)
 
-  if $::osfamily == 'Redhat' {
-    package { 'collectd-python':
-      ensure => $ensure,
-    }
-  }
-
   $conf_dir = $collectd::params::plugin_conf_dir
 
   # This is deprecated file naming ensuring old style file removed, and should be removed in next major relese


### PR DESCRIPTION
```
# yum info collectd-python
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: ...
 * epel: ...
 * extras: ...
 * updates: ...
Error: No matching Packages to list
```

Feel free to double check:

https://dl.fedoraproject.org/pub/epel/6/x86_64/
https://dl.fedoraproject.org/pub/epel/7/x86_64/c/
