### PR TITLE
Ruby 1.8.7 is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake 
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0
@@ -18,10 +14,5 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 3.5.0" STRICT_VARIABLES="yes"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.5.0" STRICT_VARIABLES="yes"
-  allow_failures:
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,10 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 3.5.0" STRICT_VARIABLES="yes"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.5.0" STRICT_VARIABLES="yes"
+  allow_failures:
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
 notifications:
   email: false

--- a/manifests/plugin/python.pp
+++ b/manifests/plugin/python.pp
@@ -11,12 +11,6 @@ define collectd::plugin::python (
 
   validate_hash($config)
 
-  if $::osfamily == 'Redhat' {
-    package { 'collectd-python':
-      ensure => $ensure,
-    }
-  }
-
   $conf_dir = $collectd::params::plugin_conf_dir
 
   # This is deprecated file naming ensuring old style file removed, and should be removed in next major relese


### PR DESCRIPTION
This patch allows the module to be tested on Ruby 1.8.7 but it won't break the build.
