### PR TITLE
Only set LogSendErrors option if collectd version >= 5.4.

### DIFF
--- a/templates/plugin/write_graphite.conf.erb
+++ b/templates/plugin/write_graphite.conf.erb
@@ -10,8 +10,8 @@
     StoreRates <%=  @storerates %>
     AlwaysAppendDS <%= @alwaysappendds %>
     SeparateInstances <%= @separateinstances %>
-    LogSendErrors <%= @logsenderrors %>
 <% if @collectd_version and (scope.function_versioncmp([@collectd_version, '5.4']) >= 0) -%>
+    LogSendErrors <%= @logsenderrors %>
     Protocol "<%= @protocol %>"
 <% end -%>
   </Carbon>


### PR DESCRIPTION
LogSendErrors was introduced in 5.4 and earlier versions complain about
'Invalid configration option: LogSendErrors'.