### PR TITLE
Allow non-root users to read plugin configuration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,7 +30,7 @@ class collectd(
   file { 'collectd.d':
     ensure  => directory,
     path    => $collectd::params::plugin_conf_dir,
-    mode    => '0750',
+    mode    => '0755',
     owner   => 'root',
     group   => $collectd::params::root_group,
     purge   => $purge,

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -17,7 +17,7 @@ define collectd::plugin (
     path    => "${conf_dir}/${order}-${plugin}.conf",
     owner   => root,
     group   => $root_group,
-    mode    => '0640',
+    mode    => '0644',
     content => template('collectd/loadplugin.conf.erb'),
     notify  => Service['collectd'],
   }


### PR DESCRIPTION
as it uses high ports only, collectd can be run as a non-root user.
moreover, collectd.conf is already 0644.
so why making things different for plugins ?
