### PR TITLE
CreateFiles/CreateFilesAsync expect boolean values

### DIFF
--- a/templates/plugin/rrdcached.conf.erb
+++ b/templates/plugin/rrdcached.conf.erb
@@ -2,10 +2,10 @@
   DaemonAddress "<%= @daemonaddress %>"
   DataDir "<%= @datadir %>"
 <% unless @createfiles.nil? -%>
-  CreateFiles "<%= @createfiles %>"
+  CreateFiles <%= @createfiles %>
 <% end -%>
 <% unless @createfilesasync.nil? -%>
-  CreateFilesAsync "<%= @createfilesasync %>"
+  CreateFilesAsync <%= @createfilesasync %>
 <% end -%>
 <% if @stepsize -%>
   StepSize "<%= @stepsize %>"


### PR DESCRIPTION

collectd: cf_util_get_boolean: The CreateFiles option requires exactly one boolean argument.
collectd: rrdcached plugin: Handling the "CreateFiles" option failed.
collectd: cf_util_get_boolean: The CreateFilesAsync option requires exactly one boolean argument.
collectd: rrdcached plugin: Handling the "CreateFilesAsync" option failed.