### PR TITLE
Fix permission on the MySQL plugin file

### DIFF
--- a/manifests/plugin/mysql/database.pp
+++ b/manifests/plugin/mysql/database.pp
@@ -28,7 +28,7 @@ define collectd::plugin::mysql::database (
   file { "${name}.conf":
     ensure  => $ensure,
     path    => "${conf_dir}/mysql-${name}.conf",
-    mode    => '0644',
+    mode    => '0640',
     owner   => 'root',
     group   => $collectd::params::root_group,
     content => template('collectd/mysql-database.conf.erb'),


### PR DESCRIPTION
This change modifies the permissions on the MySQL plugin configuration
file to avoid making it readable by everybody.