### PR TITLE
Release 3.3.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,9 @@
 fixtures:
   repositories:
-    'stdlib': 'git://github.com/puppetlabs/puppetlabs-stdlib'
-    'concat': 'git://github.com/puppetlabs/puppetlabs-concat'
+    stdlib:
+      repo: 'git://github.com/puppetlabs/puppetlabs-stdlib'
+    concat:
+      repo: 'git://github.com/puppetlabs/puppetlabs-concat'
+      ref: '1.2.0'
   symlinks:
     'collectd': "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,6 @@ fixtures:
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib'
     concat:
       repo: 'git://github.com/puppetlabs/puppetlabs-concat'
-      ref: '1.2.0'
+      ref: '1.2.1'
   symlinks:
     'collectd': "#{source_dir}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 2015-04-22 Release 3.3.0
+
+### Backwards-incompatible changes:
+
+* Drop Ruby 1.8.7 support
+* Package collectd-python is no longer available in EPEL
+
+### Features:
+
+* Allow disable forwarding in network::server
+
+### Bugs/Maint:
+
+* Fix permission on MySQL plugin file
+* Only set LogSendErrors option if collectd version >= 5.4.
+* CreateFiles/CreateFilesAsync expect boolean values
+
 ## 2015-01-24 Release 3.2.0
 
 ### Backwards-incompatible changes:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,29 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.2.8)
-    activesupport (4.2.0)
+    CFPropertyList (2.3.1)
+    activesupport (4.2.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.6)
-    archive-tar-minitar (0.5.2)
+    addressable (2.3.8)
     autoparse (0.3.3)
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    aws-sdk (1.60.2)
-      aws-sdk-v1 (= 1.60.2)
-    aws-sdk-v1 (1.60.2)
+    aws-sdk (1.64.0)
+      aws-sdk-v1 (= 1.64.0)
+    aws-sdk-v1 (1.64.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    beaker (2.1.0)
+    beaker (2.10.0)
       aws-sdk (~> 1.57)
       docker-api
       fission (~> 0.4)
       fog (~> 1.25)
-      google-api-client (~> 0.7)
+      google-api-client (~> 0.8)
       hocon (~> 0.0.4)
       inifile (~> 2.0)
       json (~> 1.8)
@@ -32,36 +31,40 @@ GEM
       net-scp (~> 1.2)
       net-ssh (~> 2.9)
       rbvmomi (~> 1.8)
+      rsync (~> 1.0.9)
       unf (~> 0.1)
-    beaker-rspec (4.0.0)
+    beaker-rspec (5.0.2)
       beaker (~> 2.0)
       rspec
-      serverspec (~> 1.0)
-      specinfra (~> 1.0)
+      serverspec (~> 2)
+      specinfra (~> 2)
     builder (3.2.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    docker-api (1.17.0)
-      archive-tar-minitar
+    docker-api (1.21.1)
       excon (>= 0.38.0)
       json
-    excon (0.42.1)
+    excon (0.45.3)
     extlib (0.9.16)
-    facter (2.3.0)
-      CFPropertyList (~> 2.2.6)
-    faraday (0.9.0)
+    facter (1.7.6)
+    faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.26.0)
+    fog (1.29.0)
       fog-atmos
+      fog-aws (~> 0.0)
       fog-brightbox (~> 0.4)
-      fog-core (~> 1.27, >= 1.27.1)
+      fog-core (~> 1.27, >= 1.27.4)
       fog-ecloud
       fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
       fog-profitbricks
       fog-radosgw (>= 0.0.2)
+      fog-riakcs
       fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
       fog-softlayer
       fog-storm_on_demand
       fog-terremark
@@ -73,102 +76,132 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
+    fog-aws (0.1.2)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
     fog-brightbox (0.7.1)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.27.2)
+    fog-core (1.30.0)
       builder
-      excon (~> 0.38)
+      excon (~> 0.45)
       formatador (~> 0.2)
       mime-types
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
-    fog-ecloud (0.0.2)
+    fog-ecloud (0.1.1)
       fog-core
       fog-xml
-    fog-json (1.0.0)
+    fog-json (1.0.1)
+      fog-core (~> 1.0)
       multi_json (~> 1.0)
-    fog-profitbricks (0.0.1)
+    fog-local (0.2.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.2)
       fog-core
       fog-xml
       nokogiri
-    fog-radosgw (0.0.3)
+    fog-radosgw (0.0.4)
       fog-core (>= 1.21.0)
       fog-json
       fog-xml (>= 0.0.1)
-    fog-sakuracloud (0.1.1)
+    fog-riakcs (0.1.0)
       fog-core
       fog-json
-    fog-softlayer (0.3.26)
+      fog-xml
+    fog-sakuracloud (1.0.1)
       fog-core
       fog-json
-    fog-storm_on_demand (0.1.0)
+    fog-serverlove (0.1.2)
       fog-core
       fog-json
-    fog-terremark (0.0.3)
+    fog-softlayer (0.4.5)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
       fog-core
       fog-xml
-    fog-vmfusion (0.0.1)
+    fog-vmfusion (0.1.0)
       fission
       fog-core
-    fog-voxel (0.0.2)
+    fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-xml (0.1.1)
+    fog-xml (0.1.2)
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
-    google-api-client (0.8.1.1)
+    google-api-client (0.8.6)
       activesupport (>= 3.2)
       addressable (~> 2.3)
       autoparse (~> 0.3)
       extlib (~> 0.9)
       faraday (~> 0.9)
+      googleauth (~> 0.3)
       launchy (~> 2.4)
       multi_json (~> 1.10)
       retriable (~> 1.4)
       signet (~> 0.6)
+    googleauth (0.4.0)
+      faraday (~> 0.9)
+      jwt (~> 1.4)
+      logging (~> 1.8)
+      memoist (~> 0.11)
+      multi_json (= 1.11)
+      signet (~> 0.6)
     hiera (1.3.4)
       json_pure
-    highline (1.6.21)
-    hocon (0.0.6)
+    hocon (0.0.7)
     i18n (0.7.0)
     inflecto (0.0.2)
     inifile (2.0.2)
     ipaddress (0.8.0)
-    json (1.8.1)
-    json_pure (1.8.1)
-    jwt (1.2.0)
+    json (1.8.2)
+    json_pure (1.8.2)
+    jwt (1.4.1)
     launchy (2.4.3)
       addressable (~> 2.3)
+    little-plugger (1.1.3)
+    logging (1.8.2)
+      little-plugger (>= 1.1.3)
+      multi_json (>= 1.8.4)
+    memoist (0.12.0)
     metaclass (0.0.4)
     mime-types (2.4.3)
-    mini_portile (0.6.1)
-    minitest (5.5.0)
+    mini_portile (0.6.2)
+    minitest (5.6.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.1)
-    nokogiri (1.6.5)
+    net-ssh (2.9.2)
+    nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    puppet (3.7.3)
+    puppet (3.7.5)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
     puppet-lint (1.1.0)
-    puppet-syntax (1.4.0)
+    puppet-syntax (2.0.0)
       rake
     puppet_facts (0.2.1)
-    puppetlabs_spec_helper (0.8.2)
+    puppetlabs_spec_helper (0.10.2)
       mocha
       puppet-lint
       puppet-syntax
       rake
-      rspec
       rspec-puppet
     rake (10.4.2)
     rbvmomi (1.8.2)
@@ -176,44 +209,51 @@ GEM
       nokogiri (>= 1.4.1)
       trollop
     retriable (1.4.1)
-    rspec (2.99.0)
-      rspec-core (~> 2.99.0)
-      rspec-expectations (~> 2.99.0)
-      rspec-mocks (~> 2.99.0)
-    rspec-core (2.99.2)
-    rspec-expectations (2.99.2)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-its (1.0.1)
-      rspec-core (>= 2.99.0.beta1)
-      rspec-expectations (>= 2.99.0.beta1)
-    rspec-mocks (2.99.2)
-    rspec-puppet (1.0.1)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-puppet (2.1.0)
       rspec
-    serverspec (1.16.0)
-      highline
-      net-ssh
-      rspec (~> 2.99)
+    rspec-support (3.2.2)
+    rsync (1.0.9)
+    serverspec (2.14.1)
+      multi_json
+      rspec (~> 3.0)
       rspec-its
-      specinfra (~> 1.27)
+      specinfra (~> 2.25)
     signet (0.6.0)
       addressable (~> 2.3)
       extlib (~> 0.9)
       faraday (~> 0.9)
       jwt (~> 1.0)
       multi_json (~> 1.10)
-    simplecov (0.9.1)
+    simplecov (0.10.0)
       docile (~> 1.1.0)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.8.0)
-    simplecov-html (0.8.0)
-    specinfra (1.27.5)
-    thread_safe (0.3.4)
-    trollop (2.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    specinfra (2.30.0)
+      net-scp
+      net-ssh
+    thread_safe (0.3.5)
+    trollop (2.1.2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.6)
+    unf_ext (0.0.7.1)
 
 PLATFORMS
   ruby

--- a/metadata.json
+++ b/metadata.json
@@ -71,7 +71,7 @@
     }
   ],
   "name": "pdxcat-collectd",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "source": "https://github.com/pdxcat/puppet-module-collectd",
   "author": "Computer Action Team",
   "license": "Apache Version 2.0",

--- a/spec/classes/collectd_init_spec.rb
+++ b/spec/classes/collectd_init_spec.rb
@@ -30,7 +30,7 @@ describe 'collectd' do
    end
 
    it 'should fail' do
-     expect { subject }.to  raise_error(/foo is not supported/)
+     should compile.and_raise_error(/foo is not supported/)
    end
  end
 

--- a/spec/classes/collectd_plugin_disk_spec.rb
+++ b/spec/classes/collectd_plugin_disk_spec.rb
@@ -35,7 +35,7 @@ describe 'collectd::plugin::disk', :type => :class do
       {:disks => 'sda'}
     end
     it 'Will raise an error about :disks being a String' do
-      expect {should}.to raise_error(Puppet::Error,/String/)
+      should compile.and_raise_error(/String/)
     end
   end
 end

--- a/spec/classes/collectd_plugin_filecount_spec.rb
+++ b/spec/classes/collectd_plugin_filecount_spec.rb
@@ -57,7 +57,7 @@ describe 'collectd::plugin::filecount', :type => :class do
       {:directories => '/var/spool/postfix/active'}
     end
     it 'Will raise an error about :directories being a String' do
-      expect {should}.to raise_error(Puppet::Error,/String/)
+      should compile.and_raise_error(/String/)
     end
   end
 end

--- a/spec/classes/collectd_plugin_interface_spec.rb
+++ b/spec/classes/collectd_plugin_interface_spec.rb
@@ -35,7 +35,7 @@ describe 'collectd::plugin::interface', :type => :class do
       {:interfaces => 'eth0'}
     end
     it 'Will raise an error about :interfaces being a String' do
-      expect {should}.to raise_error(Puppet::Error,/String/)
+      should compile.and_raise_error(/String/)
     end
   end
 end

--- a/spec/classes/collectd_plugin_iptables_spec.rb
+++ b/spec/classes/collectd_plugin_iptables_spec.rb
@@ -35,7 +35,7 @@ describe 'collectd::plugin::iptables', :type => :class do
       {:chains => ['nat','In_SSH']}
     end
     it 'Will raise an error about :chains being an Array' do
-      expect {should}.to raise_error(Puppet::Error,/Array/)
+      should compile.and_raise_error(/Array/)
     end
   end
 end

--- a/spec/classes/collectd_plugin_irq_spec.rb
+++ b/spec/classes/collectd_plugin_irq_spec.rb
@@ -35,7 +35,7 @@ describe 'collectd::plugin::irq', :type => :class do
       {:irqs => '90,91,92'}
     end
     it 'Will raise an error about :irqs being a String' do
-      expect {should}.to raise_error(Puppet::Error,/String/)
+      should compile.and_raise_error(/String/)
     end
   end
 end

--- a/spec/classes/collectd_plugin_tcpconns_spec.rb
+++ b/spec/classes/collectd_plugin_tcpconns_spec.rb
@@ -48,7 +48,7 @@ describe 'collectd::plugin::tcpconns', :type => :class do
       {:localports => '22'}
     end
     it 'Will raise an error about :localports being a String' do
-      expect {should}.to raise_error(Puppet::Error,/String/)
+      should compile.and_raise_error(/String/)
     end
   end
 
@@ -57,7 +57,7 @@ describe 'collectd::plugin::tcpconns', :type => :class do
       {:remoteports => '22'}
     end
     it 'Will raise an error about :remoteports being a String' do
-      expect {should}.to raise_error(Puppet::Error,/String/)
+      should compile.and_raise_error(/String/)
     end
   end
 end

--- a/spec/classes/collectd_plugin_unixsock_spec.rb
+++ b/spec/classes/collectd_plugin_unixsock_spec.rb
@@ -32,7 +32,7 @@ describe 'collectd::plugin::unixsock', :type => :class do
       {:socketfile => 'var/run/socket'}
     end
     it 'Will raise an error about :socketfile' do
-      expect {should}.to raise_error(Puppet::Error,/absolute path/)
+      should compile.and_raise_error(/absolute path/)
     end
   end
 end


### PR DESCRIPTION
Backwards-incompatible changes:

* Drop Ruby 1.8.7 support
* Package collectd-python is no longer available in EPEL

Features:

* Allow disable forwarding in network::server

Bugs/Maint:

* Fix permission on MySQL plugin file
* Only set LogSendErrors option if collectd version >= 5.4.
* CreateFiles/CreateFilesAsync expect boolean values