### PR TITLE
Fix CollectD not being able to start due to an indentation error.

### DIFF
--- a/templates/plugin/python/module.conf.erb
+++ b/templates/plugin/python/module.conf.erb
@@ -2,6 +2,6 @@
 
   <Module "<%= @module %>">
   <% @config.sort.each do |key,value| -%>
-    <%= key -%> <%= value %>
-  <% end -%>
+    <%= key -%> <%= value -%>
+  <% end %>
   </Module>


### PR DESCRIPTION
Fix CollectD not being able to start due to an indentation error.

```
Notice: /Stage[main]/Collectd::Plugin::Python/Concat[/etc/collectd.d/python-config.conf]/File[/etc/collectd.d/python-config.conf]/content:
--- /etc/collectd.d/python-config.conf	2015-05-27 10:23:28.631114335 +0200
+++ /tmp/puppet-file20150527-17956-16jo2pd	2015-05-27 10:26:21.561630822 +0200
@@ -6,5 +6,6 @@
   Import "puppet_reports"

   <Module "puppet_reports">
-      ReportsDir "/var/lib/puppet/reports"
-    </Module></Plugin>
+      ReportsDir "/var/lib/puppet/reports"
+  </Module>
+</Plugin>
```