### PR TITLE
quote reserved word type in tail.pp so rake validate succeeds

### DIFF
--- a/tests/plugins/tail.pp
+++ b/tests/plugins/tail.pp
@@ -5,16 +5,16 @@ collectd::plugin::tail::file { 'exim-log':
   instance => 'exim',
   matches  => [
     {
-      regex    => 'S=([1-9][0-9]*)',
-      dstype   => 'CounterAdd',
-      type     => 'ipt_bytes',
-      instance => 'total',
+      'regex'    => 'S=([1-9][0-9]*)',
+      'dstype'   => 'CounterAdd',
+      'type'     => 'ipt_bytes',
+      'instance' => 'total',
     },
     {
-      regex    => '\\<R=local_user\\>',
-      dstype   => 'CounterInc',
-      type     => 'counter',
-      instance => 'local_user',
+      'regex'    => '\\<R=local_user\\>',
+      'dstype'   => 'CounterInc',
+      'type'     => 'counter',
+      'instance' => 'local_user',
     }
   ]
 }
@@ -24,10 +24,10 @@ collectd::plugin::tail::file { 'auth-log':
   instance => 'auth',
   matches  => [
     {
-      regex    => '\\<sshd[^:]*: Accepted publickey for [^ ]+ from\\>',
-      dstype   => 'CounterInc',
-      type     => 'counter',
-      instance => 'auth-publickey',
+      'regex'    => '\\<sshd[^:]*: Accepted publickey for [^ ]+ from\\>',
+      'dstype'   => 'CounterInc',
+      'type'     => 'counter',
+      'instance' => 'auth-publickey',
     }
   ]
 }


### PR DESCRIPTION
running bundle rake validate fails with following errors:

bundle exec rake validate
ruby -c lib/facter/collectd_version.rb
Syntax OK
---> syntax:manifests
Use of reserved word: type, must be quoted if intended to be a String value at /home/piotr/git/puppet-module-collectd/tests/plugins/tail.pp:10:7
Use of reserved word: type, must be quoted if intended to be a String value at /home/piotr/git/puppet-module-collectd/tests/plugins/tail.pp:16:7
Use of reserved word: type, must be quoted if intended to be a String value at /home/piotr/git/puppet-module-collectd/tests/plugins/tail.pp:29:7
Found 3 errors. Giving up
rake aborted!


Quoting type (and all other keys to be style consistent) makes rake validate work
