### PR TITLE
snpm/host.pp validate_re validate on string

### DIFF
--- a/manifests/plugin/snmp/host.pp
+++ b/manifests/plugin/snmp/host.pp
@@ -3,7 +3,7 @@ define collectd::plugin::snmp::host (
   $collect,
   $ensure = present,
   $address = $name,
-  $version = 1,
+  $version = '1',
   $community = 'public',
   $interval = undef,
 ) {


### PR DESCRIPTION
I get errors when running "bundle exec rake spec SPEC_OPTS='--format documentation'". validate_re can only operate on strings.


collectd::plugin::snmp::host
  default params
    should contain File[snmp-host-foo.example.com.conf] with ensure => "present" and path => "/etc/collectd/conf.d/25-snmp-host-foo.example.com.conf" (FAILED - 1)
    should contain File[snmp-host-foo.example.com.conf] that notifies Service[collectd] (FAILED - 2)
    should contain File[snmp-host-foo.example.com.conf] with content =~ /<Plugin snmp>/ (FAILED - 3)
    should contain File[snmp-host-foo.example.com.conf] with content =~ /<Host "foo\.example\.com">/ (FAILED - 4)
    should contain File[snmp-host-foo.example.com.conf] with content =~ /Address "foo\.example\.com"/ (FAILED - 5)
    should contain File[snmp-host-foo.example.com.conf] with content =~ /Version 1/ (FAILED - 6)
    should contain File[snmp-host-foo.example.com.conf] with content =~ /Community "public"/ (FAILED - 7)
    should contain File[snmp-host-foo.example.com.conf] with content !~ /Interval \d+/ (FAILED - 8)
