### PR TITLE
fix cpu config parsing

### DIFF
--- a/templates/plugin/cpu.conf.erb
+++ b/templates/plugin/cpu.conf.erb
@@ -1,7 +1,7 @@
-<Plugin cpu>
 <% if @collectd_version and (scope.function_versioncmp([@collectd_version, '5.5']) >= 0) -%>
+<Plugin cpu>
   ReportByState = <%= @reportbystate %>
   ReportByCpu = <%= @reportbycpu %>
   ValuesPercentage = <%= @valuespercentage %>
-<% end -%>
 </Plugin>
+<% end -%>


### PR DESCRIPTION
The current cpu plugin breaks older collectd versions as they fail to parse the <Plugin> ...</Plugin> stuff.