### PR TITLE
fix multiple instances for curl_json

### DIFF
--- a/manifests/plugin/curl_json.pp
+++ b/manifests/plugin/curl_json.pp
@@ -13,9 +13,7 @@ define collectd::plugin::curl_json (
   validate_hash($keys)
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-curl_json':
-      ensure => $ensure,
-    }
+    ensure_packages('collectd-curl_json')
   }
 
   $conf_dir = $collectd::params::plugin_conf_dir

--- a/metadata.json
+++ b/metadata.json
@@ -79,7 +79,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0"
+      "version_requirement": ">= 3.2.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
I need multiple curl_json instances which is generated automaticly. 
Use of ensure_packages() allow to call collectd::plugin::curl_json more than once. 
