### PR TITLE
use ensure_packages for package[collectd-curl_json] in collectd::plugin::curl_json

### DIFF
--- a/manifests/plugin/curl_json.pp
+++ b/manifests/plugin/curl_json.pp
@@ -13,9 +13,7 @@ define collectd::plugin::curl_json (
   validate_hash($keys)
 
   if $::osfamily == 'Redhat' {
-    package { 'collectd-curl_json':
-      ensure => $ensure,
-    }
+    ensure_packages('collectd-curl_json')
   }
 
   $conf_dir = $collectd::params::plugin_conf_dir


### PR DESCRIPTION
if this define is multiple used on RedHat systems the package[collectd-curl_json] is declared multiple times and the compilation will fail.  ensure_packages (ensure-resource) will avoid this.