### PR TITLE
Add carbon default values as parameter to create_resources

### DIFF
--- a/manifests/plugin/write_graphite.pp
+++ b/manifests/plugin/write_graphite.pp
@@ -1,6 +1,7 @@
 # https://collectd.org/wiki/index.php/Graphite
 class collectd::plugin::write_graphite (
   $carbons           = {},
+  $carbon_defaults   = {},
   $interval          = undef,
   $ensure            = present,
   $globals           = false,
@@ -39,5 +40,5 @@ class collectd::plugin::write_graphite (
     target  => $graphite_conf,
   }
 
-  create_resources(collectd::plugin::write_graphite::carbon, $carbons)
+  create_resources(collectd::plugin::write_graphite::carbon, $carbons, $carbon_defaults)
 }


### PR DESCRIPTION
Hello:

This allows default values to be passed in for carbon blocks, and it is useful in the event that you have many unique carbon backends.

Critique welcome.

Inspiration taken from https://github.com/jfryman/puppet-nginx/blob/master/manifests/init.pp#L300