### PR TITLE
Release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 2015-07-26 Release 4.0.0
+
+### Backwards-incompatible changes:
+
+* Exec plugin was renamed from collectd::plugin::exec to collectd::plugin::exec::cmd to support multiple execs
+* Write_graphite was renamed from collectd::plugin::write_graphite to collectd::plugin::write_graphite::carbon to supports multiple carbon backends
+
+### New features
+
+* Support for the aggregation, chain, and protocols plugins
+* Swap and Memory plugins now support ValuesAbsolute and ValuesPercentage
+* OpenVPN plugin now supports multiple statusfiles
+
+### Bug fixes
+
+* Fixed bug preventing multiple instances of curl_json
+* Fixed write_http plugin on RedHat
+
 ## 2015-06-16 Release 3.4.0
 
 ### Backwards-incompatible changes:

--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,7 @@
     }
   ],
   "name": "pdxcat-collectd",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "source": "https://github.com/pdxcat/puppet-module-collectd",
   "author": "Computer Action Team",
   "license": "Apache-2.0",


### PR DESCRIPTION
Backwards-incompatible changes:

* Exec plugin was renamed from collectd::plugin::exec to collectd::plugin::exec::cmd to support multiple execs.

New features

* Support for the aggregation, chain, and protocols plugins
* Swap and Memory plugins now support ValuesAbsolute and ValuesPercentage
* OpenVPN plugin now supports multiple statusfiles

Bug fixes

* Fixed bug preventing multiple instances of curl_json
* Fixed write_http plugin on RedHat