### PR TITLE
add option to not install collectd-iptables package

### DIFF
--- a/manifests/plugin/iptables.pp
+++ b/manifests/plugin/iptables.pp
@@ -1,6 +1,7 @@
 # https://collectd.org/wiki/index.php/Plugin:IPTables
 class collectd::plugin::iptables (
   $ensure   = present,
+  $ensure_package = present,
   $chains   = {},
   $interval = undef,
 ) {
@@ -8,7 +9,7 @@ class collectd::plugin::iptables (
 
   if $::osfamily == 'Redhat' {
     package { 'collectd-iptables':
-      ensure => $ensure,
+      ensure => $ensure_package,
     }
   }
 


### PR DESCRIPTION
Needed on centos 6 for example, where the package does not exist at all.